### PR TITLE
Drop support for older Python versions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
     * Update some documentation to point to `pprintpp2` instead.
     * Use GitHub Actions instead of Travis.
     * Use `pytest` instead of `nose` (thanks @pgajdos).
+    * Removed support for older Python versions (3.7+ from now on).
 
 0.4.0
     * Add IPython plugin (thanks @roee30;

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@
     * Update some documentation to point to `pprintpp2` instead.
     * Use GitHub Actions instead of Travis.
     * Use `pytest` instead of `nose` (thanks @pgajdos).
-    * Removed support for older Python versions (3.7+ from now on).
+    * Remove support for older Python versions (3.7+ from now on).
 
 0.4.0
     * Add IPython plugin (thanks @roee30;

--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,15 @@
 ``pprint++``: a drop-in replacement for ``pprint`` that's actually pretty
 =========================================================================
 
-This is a continuation of [pprintpp](https://github.com/wolever/pprintpp), by [David Wolever](https://github.com/wolever),
-which seems to have been discontinued by the original writer. Currently, under development still.
+This is a continuation of `pprintpp <https://github.com/wolever/pprintpp>`_,
+by `David Wolever <https://github.com/wolever>`_, which seems to have been
+discontinued by the original writer. Currently, under development still.
 
 Installation
 ------------
 
 
-``pprint++`` can be installed with Python 2 or Python 3 using ``pip`` or
-``easy_install``::
+``pprint++`` can be installed using ``pip`` or ``easy_install``::
 
     $ pip install pprintpp
     - OR -

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ This is a continuation of `pprintpp <https://github.com/wolever/pprintpp>`_,
 by `David Wolever <https://github.com/wolever>`_, which seems to have been
 discontinued by the original writer. Currently, under development still.
 
+Python 3.7 and above.
+
 Installation
 ------------
 

--- a/pp/README.rst
+++ b/pp/README.rst
@@ -1,8 +1,7 @@
 ``pp``: an alias for pprint++
 =============================
 
-``pp`` can be installed with Python 2 or Python 3 using ``pip`` or
-``easy_install``::
+``pp`` can be installed with using ``pip`` or ``easy_install``::
 
     $ pip install pprintpp pp-ez
     - OR -

--- a/pp/setup.py
+++ b/pp/setup.py
@@ -31,7 +31,6 @@ setup(
         Natural Language :: English
         Operating System :: OS Independent
         Programming Language :: Python
-        Programming Language :: Python :: 2
         Programming Language :: Python :: 3
         Topic :: Software Development
         Topic :: Utilities

--- a/pprintpp/__init__.py
+++ b/pprintpp/__init__.py
@@ -12,26 +12,11 @@ __all__ = [
     "PrettyPrinter",
 ]
 
-
-#
-# Py2/Py3 compatibility stuff  # TODO: PY3
-#
-
-try:
-    from collections import OrderedDict, defaultdict, Counter
-    _test_has_collections = True
-except ImportError:
-    # Python 2.6 doesn't have collections
-    class dummy_class(object):  # TODO: PY3
-        __repr__ = object()
-    OrderedDict = defaultdict = Counter = dummy_class
-    _test_has_collections = False
+from collections import OrderedDict, defaultdict, Counter
+from .safesort import safesort
 
 
 chr_to_ascii = lambda x: ascii(x)[1:-1]
-unichr = chr
-from .safesort import safesort
-_iteritems = lambda x: x.items()  # TODO: PY3
 
 def _sorted(iterable):
     try:
@@ -39,9 +24,6 @@ def _sorted(iterable):
     except TypeError:
         return safesort(iterable)
 
-#
-# End compatibility stuff
-#
 
 class TextIO(io.TextIOWrapper):
     def __init__(self, encoding=None):
@@ -102,7 +84,7 @@ unicode_printable_categories = {
 }
 
 ascii_table = dict(
-    (unichr(i), chr_to_ascii(unichr(i)))
+    (chr(i), chr_to_ascii(chr(i)))
     for i in range(255)
 )
 
@@ -353,7 +335,7 @@ class PrettyPrinter(object):
                 state.write(": ")
                 self._format(v, state)
         elif typeish == "odict":
-            for k, v in _iteritems(object):
+            for k, v in object.items():
                 if first:
                     first = False
                 else:

--- a/pprintpp/__init__.py
+++ b/pprintpp/__init__.py
@@ -28,24 +28,16 @@ except ImportError:
     _test_has_collections = False
 
 
-BytesType = bytes  # TODO: PY3
-TextType = str  # TODO: PY3
-u_prefix = ''  # TODO: PY3
-
-
 chr_to_ascii = lambda x: ascii(x)[1:-1]
 unichr = chr
 from .safesort import safesort
-_iteritems = lambda x: x.items()
+_iteritems = lambda x: x.items()  # TODO: PY3
 
-def _sorted_py3(iterable):
+def _sorted(iterable):
     try:
         return sorted(iterable)
     except TypeError:
         return safesort(iterable)
-
-_sorted = _sorted_py3  # TODO: PY3
-_isascii = TextType.isascii  # TODO: PY3
 
 #
 # End compatibility stuff
@@ -215,7 +207,7 @@ class PPrintState(object):
             if self.write_constrain < 0:
                 raise self.WriteConstrained
 
-        if isinstance(data, BytesType):
+        if isinstance(data, bytes):
             data = data.decode("latin1")
         self.stream.write(data)
         nl_idx = data.rfind("\n")
@@ -438,12 +430,12 @@ class PrettyPrinter(object):
             write(closer)
             return
 
-        if r == BytesType.__repr__:
+        if r == bytes.__repr__:
             write(repr(object))
             return
 
-        if r == TextType.__repr__:
-            if _isascii(object):  # Optimalization
+        if r == str.__repr__:
+            if str.isascii(object):  # Optimalization
                 write(repr(object))
                 return
             if "'" in object and '"' not in object:
@@ -455,7 +447,7 @@ class PrettyPrinter(object):
             qget = quotes.get
             ascii_table_get = ascii_table.get
             unicat_get = unicodedata.category
-            write(u_prefix + quote)
+            write(quote)
             for char in object:
                 if ord(char) > 0x7F:
                     cat = unicat_get(char)

--- a/pprintpp/__init__.py
+++ b/pprintpp/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
 
 
 #
-# Py2/Py3 compatibility stuff
+# Py2/Py3 compatibility stuff  # TODO: PY3
 #
 
 try:
@@ -22,37 +22,21 @@ try:
     _test_has_collections = True
 except ImportError:
     # Python 2.6 doesn't have collections
-    class dummy_class(object):
+    class dummy_class(object):  # TODO: PY3
         __repr__ = object()
     OrderedDict = defaultdict = Counter = dummy_class
     _test_has_collections = False
 
 
-PY3 = sys.version_info >= (3, 0, 0)
-BytesType = bytes
-TextType = str if PY3 else unicode
-u_prefix = '' if PY3 else 'u'
+BytesType = bytes  # TODO: PY3
+TextType = str  # TODO: PY3
+u_prefix = ''  # TODO: PY3
 
 
-if PY3:
-    # Import builins explicitly to keep Py2 static analyzers happy
-    import builtins
-    chr_to_ascii = lambda x: builtins.ascii(x)[1:-1]
-    unichr = chr
-    from .safesort import safesort
-    _iteritems = lambda x: x.items()
-else:
-    chr_to_ascii = lambda x: repr(x)[2:-1]
-    safesort = sorted
-    _iteritems = lambda x: x.iteritems()
-
-
-def _sorted_py2(iterable):
-    with warnings.catch_warnings():
-        if getattr(sys, "py3kwarning", False):
-            warnings.filterwarnings("ignore", "comparing unequal types "
-                                    "not supported", DeprecationWarning)
-        return sorted(iterable)
+chr_to_ascii = lambda x: ascii(x)[1:-1]
+unichr = chr
+from .safesort import safesort
+_iteritems = lambda x: x.items()
 
 def _sorted_py3(iterable):
     try:
@@ -60,17 +44,8 @@ def _sorted_py3(iterable):
     except TypeError:
         return safesort(iterable)
 
-_sorted = PY3 and _sorted_py3 or _sorted_py3
-
-if hasattr(TextType, 'isascii'):  # Python>=3.7
-    _isascii = TextType.isascii
-else:
-    def _isascii(text):
-        try:
-            text.encode('ascii')
-        except UnicodeEncodeError:
-            return False
-        return True
+_sorted = _sorted_py3  # TODO: PY3
+_isascii = TextType.isascii  # TODO: PY3
 
 #
 # End compatibility stuff

--- a/pprintpp/safesort.py
+++ b/pprintpp/safesort.py
@@ -1,8 +1,5 @@
-import sys
 import textwrap
 import functools
-
-PY3 = (sys.version_info >= (3, 0, 0))
 
 def memoized_property(f):
     @functools.wraps(f)
@@ -38,9 +35,7 @@ class SafelySortable(object):
 
     @memoized_property
     def prefix(self):
-        if PY3:
-            return tuple(t.__name__ for t in type(self.obj).__mro__)
-        return type(self.obj).__mro__
+        return tuple(t.__name__ for t in type(self.obj).__mro__)
 
     @memoized_property
     def safeobj(self):
@@ -69,5 +64,4 @@ class SafelySortable(object):
 
 def safesort(input, key=None, reverse=False):
     """ Safely sort heterogeneous collections. """
-    # TODO: support cmp= on Py 2.x?
     return sorted(input, key=lambda o: SafelySortable(o, key=key), reverse=reverse)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         Natural Language :: English
         Operating System :: OS Independent
         Programming Language :: Python
-        Programming Language :: Python :: 2
         Programming Language :: Python :: 3
         Topic :: Software Development
         Topic :: Utilities

--- a/test.py
+++ b/test.py
@@ -47,7 +47,7 @@ slashed = lambda s: u"'%s'" %(
 
 @pytest.mark.skip('fix')
 @pytest.mark.parametrize("input,expected,encoding", [
-    (uni_safe, "%s'%s'" %('', uni_safe), "utf-8"),
+    (uni_safe, "'%s'" % uni_safe, "utf-8"),
     (uni_unsafe, slashed(uni_unsafe), "utf-8"),
     (uni_unsafe, slashed(uni_unsafe), "ascii"),
     ("\U0002F9B2", slashed("\U0002F9B2"), "ascii")

--- a/test.py
+++ b/test.py
@@ -41,14 +41,13 @@ def test_module_like():
 
 uni_safe = "\xe9 \u6f02 \u0e4f \u2661"
 uni_unsafe = "\u200a \u0302 \n"
-slashed = lambda s: u"%s'%s'" %(
-    p.u_prefix,
+slashed = lambda s: u"'%s'" %(
     s.encode("ascii", "backslashreplace").decode("ascii").replace("\n", "\\n")
 )
 
 @pytest.mark.skip('fix')
 @pytest.mark.parametrize("input,expected,encoding", [
-    (uni_safe, "%s'%s'" %(p.u_prefix, uni_safe), "utf-8"),
+    (uni_safe, "%s'%s'" %('', uni_safe), "utf-8"),
     (uni_unsafe, slashed(uni_unsafe), "utf-8"),
     (uni_unsafe, slashed(uni_unsafe), "ascii"),
     ("\U0002F9B2", slashed("\U0002F9B2"), "ascii")


### PR DESCRIPTION
Going forward, this project only works in Python `3.7` and above.

Code related to Python 2.x and some related to `<=3.6` was removed.

Resolves #6